### PR TITLE
feat(search): wire up search bars for licenses and obligations pages

### DIFF
--- a/src/api/api.js
+++ b/src/api/api.js
@@ -13,6 +13,7 @@ export const fetchLicenses = async ({
 	params = {},
 	sortField,
 	sortOrder,
+	search,
 }) => {
 	const base_url = `${import.meta.env.VITE_BASE_URL}/licenses?active=true&page=${page}&limit=${limit}&sort_by=${sortField}&order_by=${sortOrder}`;
 	const paramString = Object.entries(params)
@@ -21,7 +22,8 @@ export const fetchLicenses = async ({
 				`${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
 		)
 		.join('&');
-	const url = `${base_url}&${paramString}`;
+	const searchString = search ? `&search=${encodeURIComponent(search)}` : '';
+	const url = `${base_url}&${paramString}${searchString}`;
 	const headers = {};
 	if (isApiAuthenticated('licenses', 'get')) {
 		const token = await GetToken();
@@ -51,6 +53,7 @@ export const fetchObligations = async ({
 	limit = 10,
 	params = { active: true },
 	sortOrder,
+	search,
 }) => {
 	const base_url = `${import.meta.env.VITE_BASE_URL}/obligations?page=${page}&limit=${limit}&order_by=${sortOrder}`;
 	const paramString = Object.entries(params)
@@ -59,7 +62,8 @@ export const fetchObligations = async ({
 				`${encodeURIComponent(key)}=${encodeURIComponent(value)}`,
 		)
 		.join('&');
-	const url = `${base_url}&${paramString}`;
+	const searchString = search ? `&search=${encodeURIComponent(search)}` : '';
+	const url = `${base_url}&${paramString}${searchString}`;
 	const headers = {};
 	if (isApiAuthenticated('obligations', 'get')) {
 		const token = await GetToken();
@@ -465,19 +469,6 @@ export const fetchUserProfile = async token => {
 		headers['Authorization'] = `Bearer ${token}`;
 	}
 	const response = await axios.get(url, {
-		headers,
-	});
-	return response.data;
-};
-
-export const searchLicenseByShortname = async ({ queryPayload }) => {
-	const url = `${import.meta.env.VITE_BASE_URL}/search`;
-	const headers = {};
-	if (isApiAuthenticated('search', 'post')) {
-		const token = await GetToken();
-		headers['Authorization'] = `Bearer ${token}`;
-	}
-	const response = await axios.post(url, queryPayload, {
 		headers,
 	});
 	return response.data;

--- a/src/components/globalSearch.jsx
+++ b/src/components/globalSearch.jsx
@@ -4,35 +4,27 @@
 
 import React, { useEffect, useState } from 'react';
 import { ImSearch } from 'react-icons/im';
-import { useMutation } from '@tanstack/react-query';
-import { toast } from 'react-toastify';
 import { Link } from 'react-router-dom';
 import { GoPlusCircle } from 'react-icons/go';
 import Button from 'react-bootstrap/Button';
 import PropTypes from 'prop-types';
-import { searchLicenseByShortname } from '../api/api';
 
-function GlobalSearch({ response, refresh }) {
+function GlobalSearch({
+	onSearch,
+	refresh = false,
+	createLink = '/license/create',
+	createLabel = 'Create License',
+	placeholder = 'Search licenses...',
+}) {
 	const [query, setQuery] = useState('');
 
 	const handleSearch = () => {
-		if (query.trim() === '') {
-			response(null); // Notify the parent to reset the table to default
-			return;
-		}
-
-		const licenseData = {
-			field: 'shortname',
-			search: 'fuzzy',
-			search_term: query,
-		};
-
-		mutation.mutate({ queryPayload: licenseData }); // Trigger search function with the entered query
+		onSearch(query.trim());
 	};
 
 	useEffect(() => {
 		handleSearch();
-	}, [refresh])
+	}, [refresh]);
 
 	const handleKeyPress = e => {
 		if (e.key === 'Enter') {
@@ -40,30 +32,12 @@ function GlobalSearch({ response, refresh }) {
 		}
 	};
 
-	const mutation = useMutation({
-		mutationFn: searchLicenseByShortname,
-		onError: error => {
-			toast.error(`Search failed: ${error.response.data.error}`, {
-				position: 'top-right',
-				hideProgressBar: false,
-				closeOnClick: true,
-				pauseOnHover: true,
-				draggable: true,
-				progress: undefined,
-				theme: 'dark',
-			});
-		},
-		onSuccess: data => {
-			response({ ...data, data: (data.data ?? []).filter(l => l.active === true)}); // Pass search results to parent component
-		},
-	});
-
 	return (
 		<div className="table-header my-2">
-			<Link to="/license/create">
+			<Link to={createLink}>
 				<Button variant="primary">
 					<GoPlusCircle className="me-1 mb-1" />
-					Create License
+					{createLabel}
 				</Button>
 			</Link>
 			<div className="search-container">
@@ -73,7 +47,7 @@ function GlobalSearch({ response, refresh }) {
 				<div className="search-input-wrapper">
 					<input
 						type="text"
-						placeholder="Enter short name"
+						placeholder={placeholder}
 						className="search-input"
 						value={query}
 						onChange={e => setQuery(e.target.value)}
@@ -86,8 +60,11 @@ function GlobalSearch({ response, refresh }) {
 }
 
 GlobalSearch.propTypes = {
-	response: PropTypes.func.isRequired,
-	refresh: PropTypes.bool.isRequired,
+	onSearch: PropTypes.func.isRequired,
+	refresh: PropTypes.bool,
+	createLink: PropTypes.string,
+	createLabel: PropTypes.string,
+	placeholder: PropTypes.string,
 };
 
 export default GlobalSearch;

--- a/src/pages/license.jsx
+++ b/src/pages/license.jsx
@@ -3,7 +3,7 @@
 // SPDX-FileContributor: Sourav Bhowmik <sourav.bhowmik@siemens.com>
 // SPDX-FileContributor: Dearsh Oberoi <dearsh.oberoi@siemens.com>
 
-import { useState, useCallback, useRef, useEffect } from 'react';
+import { useState, useCallback, useEffect } from 'react';
 import '../styles/license.css';
 import DataTable from 'react-data-table-component';
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
@@ -36,26 +36,29 @@ function License() {
 	const isLoggedIn = GetTokenSync() !== null;
 	const [tableData, setTableData] = useState([]);
 	const [paginationData, setPaginationData] = useState();
-	const [isSearchActive, setIsSearchActive] = useState(false);
-	const filterRef = useRef(null);
+	const [searchTerm, setSearchTerm] = useState('');
 	const [refresh, setRefresh] = useState(false);
 
 	const { isPending, isError, error, data, isPreviousData } = useQuery({
-		queryKey: ['licenses', page, perPage, sortField, sortOrder],
+		queryKey: ['licenses', page, perPage, sortField, sortOrder, searchTerm],
 		queryFn: () =>
-			fetchLicenses({ page, limit: perPage, sortField, sortOrder }),
-		enabled: !isSearchActive,
+			fetchLicenses({
+				page,
+				limit: perPage,
+				sortField,
+				sortOrder,
+				search: searchTerm,
+			}),
 		placeholderData: keepPreviousData,
 	});
 
 	// Update table data when query data changes
 	useEffect(() => {
-		if (!isSearchActive && data?.data) {
-			filterRef.current = data.data;
+		if (data?.data) {
 			setTableData(data.data);
 			setPaginationData(data.paginationmeta.resource_count);
 		}
-	}, [data, isSearchActive]);
+	}, [data]);
 
 	const handleColumnClick = (sortField, sortOrder) => {
 		setSortField(sortField);
@@ -132,9 +135,7 @@ function License() {
 
 	const handleRowsChange = newPerPage => {
 		setPerPage(newPerPage);
-		if (!isSearchActive) {
-			setPage(1); // Reset to the first page
-		}
+		setPage(1); // Reset to the first page
 	};
 
 	const handleRowClicked = row => {
@@ -149,21 +150,10 @@ function License() {
 		setPage(page);
 	};
 
-	const handleHeaderData = useCallback(searchData => {
-		if (searchData?.data) {
-			setIsSearchActive(true);
-			filterRef.current = searchData.data;
-			setTableData(searchData.data);
-			setPaginationData(searchData.paginationmeta.resource_count);
-		} else {
-			resetToDefault();
-		}
+	const handleSearch = useCallback(term => {
+		setSearchTerm(term);
+		setPage(1); 
 	}, []);
-
-	const resetToDefault = () => {
-		setIsSearchActive(false);
-		setPage(1);
-	};
 
 	return (
 		<div className="content">
@@ -200,20 +190,21 @@ function License() {
 							data={tableData}
 							progressPending={isPreviousData}
 							pagination
-							paginationServer={!isSearchActive}
+							paginationServer
 							paginationTotalRows={paginationData}
 							striped
 							highlightOnHover
 							pointerOnHover
 							onChangeRowsPerPage={handleRowsChange}
-							subHeader={isLoggedIn}
 							onRowClicked={handleRowClicked}
 							onChangePage={handlePageChange}
-							subHeaderComponent={
-								<GlobalSearch
-									response={handleHeaderData}
-									refresh={refresh}
-								/>
+							subHeader={
+								isLoggedIn && (
+									<GlobalSearch
+										onSearch={handleSearch}
+										refresh={refresh}
+									/>
+								)
 							}
 						/>
 					</div>

--- a/src/pages/obligation.jsx
+++ b/src/pages/obligation.jsx
@@ -3,14 +3,10 @@
 // SPDX-FileContributor: Sourav Bhowmik <sourav.bhowmik@siemens.com>
 // SPDX-FileContributor: Dearsh Oberoi <dearsh.oberoi@siemens.com>
 
-import { useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 import DataTable from 'react-data-table-component';
 import '../styles/obligation.css';
-import { FcSearch } from 'react-icons/fc';
-import { Link } from 'react-router-dom';
-import { GoPlusCircle } from 'react-icons/go';
 import { useQuery, keepPreviousData } from '@tanstack/react-query';
-import Button from 'react-bootstrap/Button';
 import { fetchObligations } from '../api/api';
 import ObligationDetailForm from './obligationDetailForm';
 import CustomColorCell from '../components/CustomColorCell';
@@ -18,6 +14,7 @@ import '../styles/dataTable.css';
 import '../styles/globalSearch.css';
 import SortableColumnHeader from '../components/SortableColumnHeader';
 import { GetTokenSync } from '../contexts/AuthContext.jsx';
+import GlobalSearch from '../components/globalSearch';
 
 const DEFAULT_PER_PAGE = 10;
 const DEFAULT_PAGE = 1;
@@ -27,11 +24,18 @@ function Obligation() {
 	const [perPage, setPerPage] = useState(DEFAULT_PER_PAGE);
 	const [obligationPayload, setObligationPayload] = useState(null);
 	const [sortOrder, setSortOrder] = useState('asc');
+	const [searchTerm, setSearchTerm] = useState('');
 	const isLoggedIn = GetTokenSync() !== null;
 
 	const { isPending, isError, error, data, isPreviousData } = useQuery({
-		queryKey: ['obligations', page, perPage, sortOrder],
-		queryFn: () => fetchObligations({ page, limit: perPage, sortOrder }),
+		queryKey: ['obligations', page, perPage, sortOrder, searchTerm],
+		queryFn: () =>
+			fetchObligations({
+				page,
+				limit: perPage,
+				sortOrder,
+				search: searchTerm,
+			}),
 		placeholderData: keepPreviousData,
 	});
 
@@ -96,6 +100,11 @@ function Obligation() {
 		}
 	};
 
+	const handleSearch = useCallback(term => {
+		setSearchTerm(term);
+		setPage(1); // Reset to the first page for the new search
+	}, []);
+
 	return (
 		<div className="content">
 			{isPending ? (
@@ -138,18 +147,17 @@ function Obligation() {
 							highlightOnHover
 							pointerOnHover
 							onChangeRowsPerPage={handleRowsChange}
-							subHeader={isLoggedIn}
 							onRowClicked={handleRowClicked}
 							onChangePage={handlePageChange}
-							subHeaderComponent={
-								<div className="table-header my-2">
-									<Link to="/obligation/create">
-										<Button variant="primary">
-											<GoPlusCircle className="me-1 mb-1" />
-											Create Obligation
-										</Button>
-									</Link>
-								</div>
+							subHeader={
+								isLoggedIn && (
+									<GlobalSearch
+										onSearch={handleSearch}
+										createLink="/obligation/create"
+										createLabel="Create Obligation"
+										placeholder="Search obligations..."
+									/>
+								)
 							}
 						/>
 					</div>

--- a/src/pages/user.jsx
+++ b/src/pages/user.jsx
@@ -113,9 +113,8 @@ function User() {
 							onChangeRowsPerPage={handleRowsChange}
 							onRowClicked={handleRowClicked}
 							onChangePage={handlePageChange}
-							subHeader
 							paginationServer
-							subHeaderComponent={
+							subHeader={
 								<div className="table-header my-2">
 									<Link to="/user/create">
 										<Button


### PR DESCRIPTION
## Description

Wires up the license and obligation search bars on the frontend to match the merged, ranked search now available on `GET /licenses` and `GET /obligations` in the backend.

### Changes

- Fold license search into the existing paginated `GET /licenses?search=...` query instead of a separate unpaginated endpoint call.
- Add the equivalent for obligations (`GET /obligations?search=...`) — the obligations page previously had no search UI at all.
- Generalize the `GlobalSearch` component (`createLink`/`createLabel`/`placeholder` props) so it can be reused on the obligations page instead of being hardcoded to licenses.
- Fix a `react-data-table-component` v8 API mismatch (`subHeader`/`subHeaderComponent` were merged into a single `subHeader` prop in this version) that was silently hiding the search bar and "Create" buttons on the licenses, obligations and users pages.

## How to test

1. Start a backend that implements the `search` query param on `GET /licenses` and `GET /obligations` (companion change in fossology/LicenseDb, see linked issue).
2. `npm install && npm run dev`, log in.
3. On the Licenses page, confirm the search bar and "Create License" button are visible, and searching returns results ranked spdx_id > fullname > shortname > text.
4. On the Obligations page, confirm the search bar and "Create Obligation" button are now visible (previously missing), and searching returns results ranked topic > text.

Related to fossology/LicenseDb#220
